### PR TITLE
refactor: split into static and dynamic bodies

### DIFF
--- a/src/physics.ts
+++ b/src/physics.ts
@@ -480,12 +480,18 @@ export namespace physics {
             let collision = false;
 
             for (let i = world.dynamicBodies.length; i--;) {
+
+                // Only moving objects can collide if they didn't last worldStep
+                const bodyI = world.dynamicBodies[i];
+                if (!bodyI.velocity) {
+                    continue
+                }
+
                 for (let j = allEnabled.length; j-- > i;) {
                     if (i === j) {
                         continue;
                     }
                     // Test bounds
-                    const bodyI = world.dynamicBodies[i];
                     const bodyJ = allEnabled[j];
 
                     if (boundTest(bodyI, bodyJ)) {

--- a/src/physics.ts
+++ b/src/physics.ts
@@ -69,71 +69,81 @@ export namespace physics {
         depth: number;
     }
 
-    /**
-     * A rigid body in the physical world
-     */
-    export interface Body {
+    interface BodyCore {
         /** The unique ID of this body */
         id: number;
         /** The shape type of the body */
         type: ShapeType,
         /** The center of the body */
         center: Vector2,
-        /** The center of the body on average - this keeps things stable */
-        averageCenter: Vector2;
         /** The friction to apply for this body in a collision */
         friction: number,
         /** The restitution to apply for this body in a collision */
         restitution: number,
-        /** The mass of the body - zero is used for static bodies */
-        mass: number,
-        /** The current velocity of the body */
-        velocity: Vector2,
-        /** The current acceleration of the body */
-        acceleration: Vector2,
-        /** The current angle of rotation of the body */
-        angle: number,
-        /** The average angle of rotation of the bod - this keeps things stable */
-        averageAngle: number;
-        /** The current angular velocity of the body */
-        angularVelocity: number,
-        /** The current angular acceleration of the body */
-        angularAcceleration: number,
         /** The radius of a bounding circle around the body */
         bounds: number,
+        /** User data associated with the body  */
+        data: any;
+        /** Permeability of the object - anything other than zero will stop collision response */
+        permeability: number;
         /** The boding box around the body - used for efficient bounds tests */
         boundingBox: Vector2,
         /** The width of the body if its a rectangle */
         width: number,
         /** The height of the body if its a rectangle */
         height: number,
-        /** The current inertia of the body */
-        inertia: number,
+        /** The current angle of rotation of the body */
+        angle: number,
         /** The normals of the faces of the rectangle */
         faceNormals: Vector2[]
         /** The vertices of the corners of the rectangle */
         vertices: Vector2[],
-        /** The amount of time this body has been resting for */
-        restingTime: number;
         /** True if this body is static - i.e. it doesn't moved or rotate */
         static: boolean;
-        /** User data associated with the body  */
-        data: any;
-        /** Permeability of the object - anything other than zero will stop collision response */
-        permeability: number;
     }
+
+    export interface StaticRigidBody extends BodyCore {
+        static: true;
+    }
+
+    /**
+     * A rigid body in the physical world
+     */
+    export interface DynamicRigidBody extends BodyCore {
+        static: false;
+        /** The center of the body on average - this keeps things stable */
+        averageCenter: Vector2;
+        /** The mass of the body - must be non-zero for dynamic bodies */
+        mass: number,
+        /** The current velocity of the body */
+        velocity: Vector2,
+        /** The current acceleration of the body */
+        acceleration: Vector2,
+        /** The average angle of rotation of the bod - this keeps things stable */
+        averageAngle: number;
+        /** The current angular velocity of the body */
+        angularVelocity: number,
+        /** The current angular acceleration of the body */
+        angularAcceleration: number,
+        /** The current inertia of the body */
+        inertia: number,
+        /** The amount of time this body has been resting for */
+        restingTime: number;
+    }
+
+    type Body = StaticRigidBody | DynamicRigidBody
 
     /**
      * The world in which the physics engine runs
      */
     export interface World {
         /** The list of bodies that can move or rotate */
-        dynamicBodies: Body[];
+        dynamicBodies: DynamicRigidBody[];
 
         /** The list of bodies that don't move or rotate */
-        staticBodies: Body[];
+        staticBodies: StaticRigidBody[];
 
-        /** Disabled bodies */
+        /** Disabled bodies (can be either static or dynamic) */
         disabledBodies: Body[];
 
         /** The gravity to apply to all dynamic bodies */
@@ -173,11 +183,13 @@ export namespace physics {
     }
 
     export function disableBody(world: World, body: Body): void {
-        if (world.dynamicBodies.includes(body)) {
-            world.dynamicBodies.splice(world.dynamicBodies.indexOf(body), 1);
+        const dynamicBodiesId = world.dynamicBodies.findIndex((b) => b.id === body.id);
+        if (dynamicBodiesId !== -1) {
+            world.dynamicBodies.splice(dynamicBodiesId, 1);
         }
-        if (world.staticBodies.includes(body)) {
-            world.staticBodies.splice(world.staticBodies.indexOf(body), 1);
+        const staticBodiesId = world.staticBodies.findIndex((b) => b.id === body.id);
+        if (staticBodiesId !== -1) {
+            world.staticBodies.splice(staticBodiesId, 1);
         }
         if (!world.disabledBodies.includes(body)) {
             world.disabledBodies.push(body);
@@ -324,13 +336,13 @@ export namespace physics {
      * @param body The body to move
      * @param v The amount to move
      */
-    export function moveBody(body: Body, v: Vector2): void {
+    export function moveBody(body: DynamicRigidBody, v: Vector2): void {
         _moveBody(body, v, true);
     }
 
-    function _moveBody(body: Body, v: Vector2, force = false): void {
+    function _moveBody(body: DynamicRigidBody, v: Vector2, force = false): void {
         if (!force) {
-            if (body.mass === 0) {
+            if (body.static) {
                 return;
             }
         }
@@ -339,11 +351,11 @@ export namespace physics {
         body.center = addVec2(body.center, v);
 
         // Rectangle (move vertex)
-        if (body.type) {
+        if (body.type === ShapeType.RECTANGLE) {
             for (let i = 4; i--;) {
                 body.vertices[i] = addVec2(body.vertices[i], v);
             }
-            calcBoundingBox(body);
+            updateBoundingBox(body);
         }
     };
 
@@ -353,26 +365,26 @@ export namespace physics {
         body.center = v;
 
         // Rectangle (move vertex)
-        if (body.type) {
+        if (body.type === ShapeType.RECTANGLE) {
             for (let i = 4; i--;) {
                 body.vertices[i] = addVec2(body.vertices[i], v);
             }
-            calcBoundingBox(body);
+            updateBoundingBox(body);
         }
     };
 
-    export function setRotation(body: Body, angle: number): void {
+    export function setRotation(body: DynamicRigidBody, angle: number): void {
         // Update angle
         body.angle = angle;
         body.averageAngle = angle;
 
         // Rectangle (rotate vertex)
-        if (body.type) {
+        if (body.type === ShapeType.RECTANGLE) {
             for (let i = 4; i--;) {
                 body.vertices[i] = rotateVec2(body.vertices[i], body.center, angle);
             }
-            computeRectNormals(body);
-            calcBoundingBox(body);
+            updateRectNormals(body);
+            updateBoundingBox(body);
         }
     };
 
@@ -383,6 +395,10 @@ export namespace physics {
      * @param angle The angle in radian to rotate the body by
      */
     export function rotateBody(body: Body, angle: number): void {
+        if (!angle) {
+            return
+        }
+
         // Update angle
         body.angle += angle;
 
@@ -391,8 +407,8 @@ export namespace physics {
             for (let i = 4; i--;) {
                 body.vertices[i] = rotateVec2(body.vertices[i], body.center, angle);
             }
-            computeRectNormals(body);
-            calcBoundingBox(body);
+            updateRectNormals(body);
+            updateBoundingBox(body);
         }
     };
 
@@ -410,6 +426,9 @@ export namespace physics {
         world.frameCount++;
 
         for (const body of world.dynamicBodies) {
+            if (!body.velocity && !body.acceleration) {
+                continue
+            }
             // Update position/rotation
             body.velocity = addVec2(body.velocity, scaleVec2(body.acceleration, 1 / fps));
             _moveBody(body, scaleVec2(body.velocity, 1 / fps));
@@ -429,9 +448,9 @@ export namespace physics {
                     const diff = distance - joint.distance;
                     if (diff != 0) {
                         if (diff > 0) {
-                            vec = scaleVec2(vec, (1 / distance) * diff * (1 - joint.elasticity) * (other.mass === 0 ? 1 : 0.5));
+                            vec = scaleVec2(vec, (1 / distance) * diff * (1 - joint.elasticity) * (other.static ? 1 : 0.5));
                         } else {
-                            vec = scaleVec2(vec, (1 / distance) * diff * joint.rigidity * (other.mass === 0 ? 1 : 0.5));
+                            vec = scaleVec2(vec, (1 / distance) * diff * joint.rigidity * (other.static ? 1 : 0.5));
                         }
                         _moveBody(body, vec);
                         body.velocity = addVec2(body.velocity, scaleVec2(vec, fps));
@@ -510,26 +529,20 @@ export namespace physics {
             }
         }
 
-        for (const body of all) {
-            if (body.mass > 0) {
-                body.restingTime += 1 / fps;
+        for (const body of world.dynamicBodies) {
+            body.restingTime += 1 / fps;
 
-                if (Math.abs(body.center.x - body.averageCenter.x) > 1) {
-                    body.averageCenter.x = body.center.x;
-                    body.restingTime = 0;
-                }
-                if (Math.abs(body.center.y - body.averageCenter.y) > 1) {
-                    body.averageCenter.y = body.center.y;
-                    body.restingTime = 0;
-                }
-                if (Math.abs(body.angle - body.averageAngle) >= 0.1) {
-                    body.averageAngle = body.angle;
-                    body.restingTime = 0;
-                }
-            } else {
+            if (Math.abs(body.center.x - body.averageCenter.x) > 1) {
                 body.averageCenter.x = body.center.x;
+                body.restingTime = 0;
+            }
+            if (Math.abs(body.center.y - body.averageCenter.y) > 1) {
                 body.averageCenter.y = body.center.y;
+                body.restingTime = 0;
+            }
+            if (Math.abs(body.angle - body.averageAngle) >= 0.1) {
                 body.averageAngle = body.angle;
+                body.restingTime = 0;
             }
         }
 
@@ -676,46 +689,59 @@ export namespace physics {
 
     // New shape
     function createRigidBody(world: World, center: Vector2, mass: number, friction: number, restitution: number, type: number, bounds: number, width = 0, height = 0): Body {
-        const body: Body = {
-            id: world.nextId++,
-            type: type, // 0 circle / 1 rectangle
-            center: center, // center
-            averageCenter: newVec2(center.x, center.y),
-            friction: friction, // friction
-            restitution: restitution, // restitution (bouncing)
-            mass: mass ? 1 / mass : 0, // inverseMass (0 if immobile)
-            velocity: newVec2(0, 0), // velocity (speed)
-            acceleration: mass ? world.gravity : newVec2(0, 0), // acceleration
-            angle: 0, // angle
-            averageAngle: 0,
-            angularVelocity: 0, // angle velocity
-            angularAcceleration: 0, // angle acceleration
-            bounds: bounds, // (bounds) radius
-            width: width, // width
-            height: height, // height
-            inertia: calculateInertia(type, mass, bounds, width, height),
-            faceNormals: [], // face normals array (rectangles)
-            vertices: [ // Vertex: 0: TopLeft, 1: TopRight, 2: BottomRight, 3: BottomLeft (rectangles)
+
+        // Prepare data for Rectangle
+        let vertices: Vector2[], faceNormals: Vector2[]
+        if (type === ShapeType.RECTANGLE)
+        {
+            vertices = [ // Vertex: 0: TopLeft, 1: TopRight, 2: BottomRight, 3: BottomLeft (rectangles)
                 newVec2(center.x - width / 2, center.y - height / 2),
                 newVec2(center.x + width / 2, center.y - height / 2),
                 newVec2(center.x + width / 2, center.y + height / 2),
                 newVec2(center.x - width / 2, center.y + height / 2)
-            ],
-            boundingBox: newVec2(0, 0),
-            restingTime: mass == 0 ? Number.MAX_SAFE_INTEGER : 0,
-            data: null,
-            static: mass === 0,
-            permeability: 0
-        };
-
-        calcBoundingBox(body);
-
-        // Prepare rectangle
-        if (type /* == 1 */) {
-            computeRectNormals(body);
+            ]
+            faceNormals = computeRectNormals(vertices)
+        } else {
+            vertices = []
+            faceNormals = []
         }
 
-        return body;
+        const staticBody: StaticRigidBody = {
+            id: world.nextId++,
+            type,
+            center,
+            friction,
+            restitution,
+            bounds,
+            boundingBox: calcBoundingBox(type, bounds, vertices, center),
+            width,
+            height,
+            faceNormals,
+            vertices,
+            static: true,
+            angle: 0,
+            permeability: 0,
+            data: null
+        }
+
+        if (!mass) {
+            return staticBody
+        } else {
+            const dynamicBody: DynamicRigidBody = {
+                ...staticBody,
+                static: false,
+                averageCenter: newVec2(center.x, center.y),
+                mass: 1 / mass, // inverseMass
+                velocity: newVec2(0, 0), // velocity (speed)
+                acceleration: world.gravity, // acceleration
+                averageAngle: 0,
+                angularVelocity: 0, // angle velocity
+                angularAcceleration: 0, // angle acceleration,
+                inertia: calculateInertia(type, mass, bounds, width, height),
+                restingTime: 0,
+            }
+            return dynamicBody
+        }
     }
 
     /**
@@ -725,7 +751,11 @@ export namespace physics {
      * @param body The body to add
      */
     export function addBody(world: World, body: Body): void {
-        (body.static ? world.staticBodies : world.dynamicBodies).push(body);
+        if (body.static) {
+            world.staticBodies.push(body)
+        } else {
+            world.dynamicBodies.push(body)
+        }
     }
 
     /**
@@ -754,29 +784,46 @@ export namespace physics {
         // return lengthVec2(subtractVec2(s2.center, s1.center)) <= s1.bounds + s2.bounds;
     }
 
-    function calcBoundingBox(body: Body) {
-        if (body.type === ShapeType.CIRCLE) {
-            body.boundingBox.x = body.bounds;
-            body.boundingBox.y = body.bounds;
-        } else {
-            body.boundingBox.x = 0;
-            body.boundingBox.y = 0;
+    function updateBoundingBox(body: Body): void {
+        body.boundingBox = calcBoundingBox(body.type, body.bounds, body.vertices, body.center)
+    }
 
-            for (const v of body.vertices) {
-                body.boundingBox.x = Math.max(body.boundingBox.x, Math.abs(body.center.x - v.x));
-                body.boundingBox.y = Math.max(body.boundingBox.y, Math.abs(body.center.y - v.y));
+    function calcBoundingBox(type: number, bounds: number, vertices: Vector2[], center: Vector2): Vector2 {
+        if (type === ShapeType.CIRCLE) {
+            return {
+                x: bounds,
+                y: bounds
+            }
+        } else {
+            let x = 0, y = 0
+
+            for (const v of vertices) {
+                x = Math.max(x, Math.abs(center.x - v.x));
+                y = Math.max(y, Math.abs(center.y - v.y));
+            }
+            return {
+                x,
+                y
             }
         }
     }
 
+    function updateRectNormals(body: Body) {
+        body.faceNormals = computeRectNormals(body.vertices)
+    }
+
     // Compute face normals (for rectangles)
-    function computeRectNormals(shape: Body): void {
+    function computeRectNormals(vertices: Vector2[]): Vector2[] {
+
+        const faceNormals = []
 
         // N: normal of each face toward outside of rectangle
         // 0: Top, 1: Right, 2: Bottom, 3: Left
         for (let i = 4; i--;) {
-            shape.faceNormals[i] = normalize(subtractVec2(shape.vertices[(i + 1) % 4], shape.vertices[(i + 2) % 4]));
+            faceNormals[i] = normalize(subtractVec2(vertices[(i + 1) % 4], vertices[(i + 2) % 4]));
         }
+
+        return faceNormals
     }
 
     // Find the axis of least penetration between two rects
@@ -839,7 +886,7 @@ export namespace physics {
     // Test collision between two shapes
     function testCollision(world: World, c1: Body, c2: Body, collisionInfo: CollisionDetails): boolean {
         // static bodies don't collide with each other
-        if ((c1.mass === 0 && c2.mass === 0)) {
+        if ((c1.static && c2.static)) {
             return false;
         }
 
@@ -988,13 +1035,19 @@ export namespace physics {
     }
 
     function resolveCollision(world: World, s1: Body, s2: Body, collisionInfo: CollisionDetails): boolean {
-        if (!s1.mass && !s2.mass) {
+        if (s1.static && s2.static) {
             return false;
         }
 
+        const
+            mass1 = !s1.static ? s1.mass : 0,
+            mass2 = !s2.static ? s2.mass : 0,
+            inertia1 = !s1.static ? s1.inertia : 0,
+            inertia2 = !s2.static ? s2.inertia : 0;
+
         // correct positions
         const
-            num = collisionInfo.depth / (s1.mass + s2.mass) * .8, // .8 = poscorrectionrate = percentage of separation to project objects
+            num = collisionInfo.depth / (mass1 + mass2) * .8, // .8 = poscorrectionrate = percentage of separation to project objects
             correctionAmount = scaleVec2(collisionInfo.normal, num),
             n = collisionInfo.normal;
 
@@ -1002,22 +1055,26 @@ export namespace physics {
             return false;
         }
 
-        _moveBody(s1, scaleVec2(correctionAmount, -s1.mass));
-        _moveBody(s2, scaleVec2(correctionAmount, s2.mass));
+        if (!s1.static) {
+            _moveBody(s1, scaleVec2(correctionAmount, -mass1));
+        }
+        if (!s2.static) {
+            _moveBody(s2, scaleVec2(correctionAmount, mass2));
+        }
 
         // the direction of collisionInfo is always from s1 to s2
         // but the Mass is inversed, so start scale with s2 and end scale with s1
         const
-            start = scaleVec2(collisionInfo.start, s2.mass / (s1.mass + s2.mass)),
-            end = scaleVec2(collisionInfo.end, s1.mass / (s1.mass + s2.mass)),
+            start = scaleVec2(collisionInfo.start, mass2 / (mass1 + mass2)),
+            end = scaleVec2(collisionInfo.end, mass1 / (mass1 + mass2)),
             p = addVec2(start, end),
             // r is vector from center of object to collision point
             r1 = subtractVec2(p, s1.center),
             r2 = subtractVec2(p, s2.center),
 
             // newV = V + v cross R
-            v1 = addVec2(s1.velocity, newVec2(-1 * s1.angularVelocity * r1.y, s1.angularVelocity * r1.x)),
-            v2 = addVec2(s2.velocity, newVec2(-1 * s2.angularVelocity * r2.y, s2.angularVelocity * r2.x)),
+            v1 = !s1.static ? addVec2(s1.velocity, newVec2(-1 * s1.angularVelocity * r1.y, s1.angularVelocity * r1.x)) : newVec2(0, 0),
+            v2 = !s2.static ? addVec2(s2.velocity, newVec2(-1 * s2.angularVelocity * r2.y, s2.angularVelocity * r2.x)) : newVec2(0, 0),
             relativeVelocity = subtractVec2(v2, v1),
 
             // Relative velocity in normal direction
@@ -1039,7 +1096,7 @@ export namespace physics {
 
             // Calc impulse scalar
             // the formula of jN can be found in http://www.myphysicslab.com/collision.html
-            jN = (-(1 + newRestituion) * rVelocityInNormal) / (s1.mass + s2.mass + R1crossN * R1crossN * s1.inertia + R2crossN * R2crossN * s2.inertia);
+            jN = (-(1 + newRestituion) * rVelocityInNormal) / (mass1 + mass2 + R1crossN * R1crossN * inertia1 + R2crossN * R2crossN * inertia2);
         let
             // impulse is in direction of normal ( from s1 to s2)
             impulse = scaleVec2(n, jN);
@@ -1060,7 +1117,7 @@ export namespace physics {
             R1crossT = crossProduct(r1, tangent),
             R2crossT = crossProduct(r2, tangent);
         let
-            jT = (-(1 + newRestituion) * dotProduct(relativeVelocity, tangent) * newFriction) / (s1.mass + s2.mass + R1crossT * R1crossT * s1.inertia + R2crossT * R2crossT * s2.inertia);
+            jT = (-(1 + newRestituion) * dotProduct(relativeVelocity, tangent) * newFriction) / (mass1 + mass2 + R1crossT * R1crossT * inertia1 + R2crossT * R2crossT * inertia2);
 
         // friction should less than force in normal direction
         if (jT > jN) {
@@ -1087,136 +1144,5 @@ export namespace physics {
         }
 
         return true;
-    }
-
-    /**
-     * Create a demo scene to test out physics 
-     * 
-     * @param count The number of elements to create
-     * @param withBoxes True if we want to include boxes in the demo
-     * @returns The demo scene as a physics world
-     */
-    export function createDemoScene(count: number, withBoxes: boolean): World {
-        // DEMO
-        // ====
-        const world = createWorld();
-
-        let r = createRectangle(world, newVec2(500, 200), 400, 20, 0, 1, .5);
-        rotateBody(r, 2.8);
-        createRectangle(world, newVec2(200, 400), 400, 20, 0, 1, .5);
-        createRectangle(world, newVec2(100, 200), 200, 20, 0, 1, .5);
-        createRectangle(world, newVec2(10, 360), 20, 100, 0, 1, .5);
-
-        for (let i = 0; i < count; i++) {
-            r = createCircle(world, newVec2(Math.random() * 800, Math.random() * 450 / 2), Math.random() * 20 + 10, Math.random() * 30, Math.random() / 2, Math.random() / 2);
-            rotateBody(r, Math.random() * 7);
-            if (withBoxes) {
-                r = createRectangle(world, newVec2(Math.random() * 800, Math.random() * 450 / 2), Math.random() * 20 + 10, Math.random() * 20 + 10, Math.random() * 30, Math.random() / 2, Math.random() / 2);
-                rotateBody(r, Math.random() * 7);
-            }
-        }
-
-        return world;
-    }
-
-
-    /// A simple puck table for lighter physics
-    export interface Table {
-        pucks: Puck[];
-        friction: number;
-        nextId: number;
-    }
-
-    export interface Puck {
-        id: number;
-        position: Vector2;
-        velocity: Vector2;
-        radius: number;
-        mass: number;
-    }
-
-    export interface PuckCollision {
-        puckIdA: number;
-        puckIdB: number;
-    }
-
-    export function createTable(): Table {
-        return {
-            pucks: [],
-            friction: 0.01,
-            nextId: 1,
-        };
-    }
-
-    export function createPuck(table: Table, x: number, y: number, radius: number): Puck {
-        return { id: table.nextId++, position: newVec2(x, y), radius, velocity: newVec2(0, 0), mass: radius * 10};
-    }
-
-    export function tableStep(fps: number, table: Table): PuckCollision[] {
-        const collisions: PuckCollision[] = [];
-
-        for (const puck of table.pucks) {
-            puck.velocity.x -= (puck.velocity.x * table.friction) / fps;
-            puck.velocity.y -= (puck.velocity.y * table.friction) / fps;
-            puck.position.x += puck.velocity.x / fps;
-            puck.position.y += puck.velocity.y / fps;
-        }
-
-        const efficiency = 1;
-
-        // 10 iterations for collision resolution
-        for (let i=0;i<10;i++) {
-            for (const puckA of table.pucks) {
-                for (const puckB of table.pucks) {
-                    if (puckA === puckB) {
-                        continue;
-                    }
-
-                    // test for collision
-                    const nx = puckB.position.x - puckA.position.x;
-                    const ny = puckB.position.y - puckA.position.y;
-                    const len2 = (nx * nx) + (ny * ny);
-                    const rad = (puckB.radius + puckA.radius);
-                    const rad2 = rad * rad;
-                    if (rad2 > len2) {
-                        // close enough for collision
-                        const len = Math.sqrt(len2);
-
-                        // move out of collision
-                        const normal = scaleVec2(newVec2(nx, ny), 1 / len);
-                        const penetration = len - rad;
-                        const penOver2 = penetration / 2;
-                        puckA.position.x -= penOver2 * normal.x;
-                        puckA.position.y -= penOver2 * normal.y;
-                        puckB.position.x += penOver2 * normal.x;
-                        puckB.position.y += penOver2 * normal.y;
-
-                        const tangent = newVec2(-normal.y, normal.x);
-
-                        // change velocity of pucks based on the collision
-                        const dpTanA = dotProduct(tangent, puckA.velocity);
-                        const dpTanB = dotProduct(tangent, puckB.velocity);
-                        const dpNormA = dotProduct(normal, puckA.velocity);
-                        const dpNormB = dotProduct(normal, puckB.velocity);
-
-                        const m1 = efficiency * ((dpNormA * (puckA.mass - puckB.mass)) + (2.0 * puckB.mass * dpNormB)) / (puckA.mass + puckB.mass);
-                        const m2 = efficiency * ((dpNormB * (puckB.mass - puckA.mass)) + (2.0 * puckA.mass * dpNormA)) / (puckA.mass + puckB.mass);
-    
-                        // Update puck velocities
-                        puckA.velocity.x = (tangent.x * dpTanA) + (normal.x * m1);
-                        puckA.velocity.y = (tangent.y * dpTanA) + (normal.y * m1);
-                        puckB.velocity.x = (tangent.x * dpTanB) + (normal.x * m2)
-                        puckB.velocity.y = (tangent.y * dpTanB) + (normal.y * m2);
-
-                        collisions.push({
-                            puckIdA: puckA.id,
-                            puckIdB: puckB.id
-                        });
-                    }
-                }
-            }
-        }
-
-        return collisions;
     }
 }


### PR DESCRIPTION
Really fun to dive into how the physics are implemented! As discussed, this PR splits the types for static and dynamic bodies so that static bodies don't have acceleration etc.

I got a bit overboard and got too excited as I was thinking about how to apply this for a game I want to make 😅 Made some other tweaks.

Some perf improvements:
- Don't update position + angle updates for dynamic objects that are at rest
- Don't check for collisions for dynamic objects that are at rest
- Don't update static objects with `averageCenter` etc.
- Don't update bounding boxes etc. when `rotateBody()` is called with `angle === 0`
- Compute new bounding box / RectNormals and update body in 1 step (should help a bit with perf with immutability libraries)

Some minor QOL changes:
- Always using `static` variable for distinguishing between static and dynamic bodies (instead of sometimes using `mass`)
- Always using `type === ShapeType`

Of course, feel free to modify and only pick changes you think are useful. You can also let me know which changes you like/dislike and I can update the PR accordingly.